### PR TITLE
fix: issue with minting

### DIFF
--- a/src/components/assets/create-asset.tsx
+++ b/src/components/assets/create-asset.tsx
@@ -209,9 +209,9 @@ export default function CreateAssetView() {
         calls: [
           {
             contractAddress: MEDIOLANO_CONTRACT,
-            entrypoint: "mint",
+            entrypoint: "mint_item",
             calldata: [
-              values.collection, //
+              publicKey, //
               result.cid, // tokenURI (metadata)
             ],
           },


### PR DESCRIPTION
This PR adds support for minting NFTs using the Chippi SDK.

### Details

* Integrates Chippi SDK into the NFT minting flow
* Enables users to mint NFTs directly through the dApp interface

### Related Issue

Closes [#23](https://github.com/mediolano-app/mip-dapp/issues/23)
