### PR TITLE
Added swagger docs.

### DIFF
--- a/backend/API-DOCS.MD
+++ b/backend/API-DOCS.MD
@@ -1,0 +1,354 @@
+# NFT Indexer API Documentation
+
+A comprehensive API for querying indexed NFT data from Starknet contracts using Fastify and Drizzle ORM.
+
+## Features
+
+- **Assets API**: Query NFTs by owner, collection, or search
+- **Collections API**: Query collections by creator or search
+- **Transfers API**: Query transfer history by token or address
+- **Stats API**: Get analytics and statistics
+- Support for multiple indexer sources (MEDIALANO-DAPP, MEDIALANO-MIPP)
+- Pagination support for all endpoints
+- Comprehensive filtering and sorting options
+
+## Setup
+
+### Prerequisites
+
+- Node.js 18+
+- PostgreSQL database
+- Environment variables configured
+
+### Installation
+Read the README.MD.
+
+## API Endpoints
+
+### Assets
+
+#### Get Assets by Owner
+
+```
+GET /assets/owner/:owner
+```
+
+Query parameters:
+- `indexerSource` (optional): Filter by indexer source ("MEDIALANO-DAPP" | "MEDIALANO-MIPP")
+- `collectionId` (optional): Filter by collection ID
+- `limit` (optional): Number of results (1-100, default: 20)
+- `offset` (optional): Pagination offset (default: 0)
+- `sortBy` (optional): Sort field ("mintedAtBlock" | "id", default: "mintedAtBlock")
+- `sortOrder` (optional): Sort direction ("asc" | "desc", default: "desc")
+
+**Example:**
+```bash
+curl "http://localhost:3000/assets/owner/0x1234...?limit=10&indexerSource=MEDIALANO-DAPP"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "MEDIALANO-DAPP_123",
+      "collectionId": "MEDIALANO-DAPP_456",
+      "owner": "0x1234...",
+      "tokenUri": "ipfs://...",
+      "mintedAtBlock": 12345,
+      "indexerSource": "MEDIALANO-DAPP",
+      "collection": {
+        "id": "MEDIALANO-DAPP_456",
+        "creator": "0x5678...",
+        "metadataUri": "ipfs://...",
+        "createdAtBlock": 12300,
+        "indexerSource": "MEDIALANO-DAPP"
+      }
+    }
+  ],
+  "pagination": {
+    "total": 25,
+    "limit": 10,
+    "offset": 0,
+    "hasMore": true
+  }
+}
+```
+
+#### Get Single Asset
+
+```
+GET /assets/:id
+```
+
+**Example:**
+```bash
+curl "http://localhost:3000/assets/MEDIALANO-DAPP_123"
+```
+
+#### Get All Assets
+
+```
+GET /assets
+```
+
+Query parameters:
+- `indexerSource` (optional): Filter by indexer source
+- `collectionId` (optional): Filter by collection ID
+- `search` (optional): Search in asset IDs
+- `limit`, `offset`, `sortBy`, `sortOrder`: Same as above
+
+### Collections
+
+#### Get Collections by Creator
+
+```
+GET /collections/creator/:creator
+```
+
+Query parameters:
+- `indexerSource` (optional): Filter by indexer source
+- `limit`, `offset`, `sortBy`, `sortOrder`: Pagination and sorting options
+
+**Example:**
+```bash
+curl "http://localhost:3000/collections/creator/0x1234...?limit=5"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "MEDIALANO-DAPP_456",
+      "creator": "0x1234...",
+      "metadataUri": "ipfs://...",
+      "createdAtBlock": 12300,
+      "indexerSource": "MEDIALANO-DAPP",
+      "assetCount": 150
+    }
+  ],
+  "pagination": {
+    "total": 3,
+    "limit": 5,
+    "offset": 0,
+    "hasMore": false
+  }
+}
+```
+
+#### Get Single Collection
+
+```
+GET /collections/:id
+```
+
+Returns collection details with asset count and recent assets.
+
+#### Get All Collections
+
+```
+GET /collections
+```
+
+Query parameters:
+- `indexerSource` (optional): Filter by indexer source
+- `creator` (optional): Filter by creator address
+- `search` (optional): Search in collection IDs
+- `limit`, `offset`, `sortBy`, `sortOrder`: Pagination and sorting options
+
+### Transfers
+
+#### Get Transfers by Token
+
+```
+GET /transfers/token/:tokenId
+```
+
+Query parameters:
+- `limit`, `offset`: Pagination options
+- `sortOrder`: Sort by block number ("asc" | "desc", default: "desc")
+
+**Example:**
+```bash
+curl "http://localhost:3000/transfers/token/MEDIALANO-DAPP_123"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "12345_0x789..._1",
+      "tokenId": "MEDIALANO-DAPP_123",
+      "from": "0x0000...",
+      "to": "0x1234...",
+      "block": 12345,
+      "indexerSource": "MEDIALANO-DAPP",
+      "asset": {
+        "id": "MEDIALANO-DAPP_123",
+        "collectionId": "MEDIALANO-DAPP_456",
+        "tokenUri": "ipfs://...",
+        "owner": "0x1234..."
+      }
+    }
+  ],
+  "pagination": {
+    "total": 3,
+    "limit": 20,
+    "offset": 0,
+    "hasMore": false
+  }
+}
+```
+
+#### Get All Transfers
+
+```
+GET /transfers
+```
+
+Query parameters:
+- `tokenId` (optional): Filter by token ID
+- `from` (optional): Filter by sender address
+- `to` (optional): Filter by recipient address
+- `indexerSource` (optional): Filter by indexer source
+- `limit`, `offset`, `sortBy`, `sortOrder`: Pagination and sorting options
+
+### Statistics
+
+#### Get Overall Stats
+
+```
+GET /stats
+```
+
+**Example Response:**
+```json
+{
+  "data": {
+    "totalAssets": 1250,
+    "totalCollections": 45,
+    "totalTransfers": 2100,
+    "assetsByIndexer": [
+      {
+        "indexerSource": "MEDIALANO-DAPP",
+        "count": 800
+      },
+      {
+        "indexerSource": "MEDIALANO-MIPP",
+        "count": 450
+      }
+    ],
+    "collectionsByIndexer": [
+      {
+        "indexerSource": "MEDIALANO-DAPP",
+        "count": 44
+      },
+      {
+        "indexerSource": "MEDIALANO-MIPP",
+        "count": 1
+      }
+    ],
+    "recentActivity": [
+      {
+        "id": "12346_0x789..._1",
+        "tokenId": "MEDIALANO-DAPP_124",
+        "from": "0x1111...",
+        "to": "0x2222...",
+        "block": 12346,
+        "indexerSource": "MEDIALANO-DAPP"
+      }
+    ]
+  }
+}
+```
+
+#### Get Stats by Indexer
+
+```
+GET /stats/indexer?indexerSource=MEDIALANO-DAPP
+```
+
+Returns detailed statistics for a specific indexer including top collections, top owners, and recent mints.
+
+### Health Check
+
+```
+GET /health
+```
+
+Returns server health status.
+
+## Response Format
+
+All API responses follow this format:
+
+```json
+{
+  "data": { /* response data */ },
+  "pagination": { /* pagination info for list endpoints */ }
+}
+```
+
+Error responses:
+```json
+{
+  "error": "Error message"
+}
+```
+
+## HTTP Status Codes
+
+- `200 OK`: Successful request
+- `404 Not Found`: Resource not found
+- `400 Bad Request`: Invalid request parameters
+- `500 Internal Server Error`: Server error
+
+## Filtering and Sorting
+
+### Indexer Sources
+
+All endpoints support filtering by `indexerSource`:
+- `MEDIALANO-DAPP`: Assets from the main dApp contract
+- `MEDIALANO-MIPP`: Assets from the MIP contract
+
+### Pagination
+
+All list endpoints support pagination:
+- `limit`: Number of results (1-100)
+- `offset`: Number of results to skip
+- Response includes `hasMore` boolean for easy pagination
+
+### Sorting
+
+List endpoints support sorting:
+- `sortBy`: Field to sort by (varies by endpoint)
+- `sortOrder`: "asc" or "desc"
+
+## Examples
+
+### Get all NFTs owned by an address
+```bash
+curl "http://localhost:3000/assets/owner/0x1234567890abcdef?limit=50&sortOrder=desc"
+```
+
+### Get collections created by an address from DAPP indexer only
+```bash
+curl "http://localhost:3000/collections/creator/0x1234567890abcdef?indexerSource=MEDIALANO-DAPP"
+```
+
+### Get transfer history for a specific NFT
+```bash
+curl "http://localhost:3000/transfers/token/MEDIALANO-DAPP_123"
+```
+
+### Search for assets in a specific collection
+```bash
+curl "http://localhost:3000/assets?collectionId=MEDIALANO-DAPP_456&limit=100"
+```
+
+### Get recent activity across all indexers
+```bash
+curl "http://localhost:3000/transfers?limit=20&sortBy=block&sortOrder=desc"
+```

--- a/backend/README.MD
+++ b/backend/README.MD
@@ -89,6 +89,10 @@ POSTGRES_CONNECTION_STRING=
    ```bash
    pnpm run api:dev
    ```
+5. Swagger can be accessed on PORT/docs:
+   ```bash
+   http://localhost:3000/docs
+   ```
 
 ---
 

--- a/backend/lib/db.api.ts
+++ b/backend/lib/db.api.ts
@@ -1,0 +1,20 @@
+
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+
+const pool = new Pool({
+  connectionString: process.env.POSTGRES_CONNECTION_STRING,
+});
+
+// Test connection on startup
+pool.connect()
+  .then((client) => {
+    console.log("✅ Database connected successfully");
+    client.release();
+  })
+  .catch((err) => {
+    console.error("❌ Failed to connect to the database:", err.message);
+    process.exit(1); // Exit app if DB is unreachable
+  });
+
+export const db = drizzle(pool);

--- a/backend/lib/util.ts
+++ b/backend/lib/util.ts
@@ -1,4 +1,6 @@
 import { shortString } from "starknet";
+import { readFileSync } from "fs";
+import yaml from "yaml";
 
 /**
  * Convert array of felts into a string.
@@ -28,3 +30,7 @@ export function feltsToString(felts: string[]): string {
 export function feltToAddress(f: string): string {
   return "0x" + BigInt(f).toString(16).padStart(64, "0");
 }
+
+
+
+export const openapiSpec = yaml.parse(readFileSync("./openapi.yaml", "utf-8"));

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,326 @@
+openapi: 3.0.3
+info:
+  title: NFT Indexer API
+  version: 1.0.0
+  description: API for querying indexed NFT data from Starknet contracts.
+
+servers:
+  - url: http://localhost:3000/api
+    description: Local development
+
+paths:
+  /assets:
+    get:
+      summary: Get all assets
+      parameters:
+        - in: query
+          name: indexerSource
+          schema: { type: string, enum: [MEDIALANO-DAPP, MEDIALANO-MIPP] }
+        - in: query
+          name: collectionId
+          schema: { type: string }
+        - in: query
+          name: search
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+        - in: query
+          name: sortBy
+          schema:
+            { type: string, enum: [mintedAtBlock, id], default: mintedAtBlock }
+        - in: query
+          name: sortOrder
+          schema: { type: string, enum: [asc, desc], default: desc }
+      responses:
+        "200":
+          description: List of assets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedAssets"
+
+  /assets/{id}:
+    get:
+      summary: Get single asset
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Single asset
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Asset"
+
+  /assets/owner/{owner}:
+    get:
+      summary: Get assets by owner
+      parameters:
+        - in: path
+          name: owner
+          required: true
+          schema: { type: string }
+        - in: query
+          name: indexerSource
+          schema: { type: string, enum: [MEDIALANO-DAPP, MEDIALANO-MIPP] }
+        - in: query
+          name: collectionId
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Assets owned by address
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedAssets"
+
+  /collections:
+    get:
+      summary: Get all collections
+      parameters:
+        - in: query
+          name: indexerSource
+          schema: { type: string }
+        - in: query
+          name: creator
+          schema: { type: string }
+        - in: query
+          name: search
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: List of collections
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedCollections"
+
+  /collections/{id}:
+    get:
+      summary: Get single collection
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Collection details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Collection"
+
+  /collections/creator/{creator}:
+    get:
+      summary: Get collections by creator
+      parameters:
+        - in: path
+          name: creator
+          required: true
+          schema: { type: string }
+        - in: query
+          name: indexerSource
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Creator’s collections
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedCollections"
+
+  /transfers:
+    get:
+      summary: Get all transfers
+      parameters:
+        - in: query
+          name: tokenId
+          schema: { type: string }
+        - in: query
+          name: from
+          schema: { type: string }
+        - in: query
+          name: to
+          schema: { type: string }
+        - in: query
+          name: indexerSource
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+        - in: query
+          name: sortOrder
+          schema: { type: string, enum: [asc, desc], default: desc }
+      responses:
+        "200":
+          description: Transfer list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedTransfers"
+
+  /transfers/token/{tokenId}:
+    get:
+      summary: Get transfers by token
+      parameters:
+        - in: path
+          name: tokenId
+          required: true
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Transfers for token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedTransfers"
+
+  /stats:
+    get:
+      summary: Get overall stats
+      responses:
+        "200":
+          description: API statistics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Stats"
+
+  /stats/indexer:
+    get:
+      summary: Get stats by indexer
+      parameters:
+        - in: query
+          name: indexerSource
+          schema: { type: string }
+      responses:
+        "200":
+          description: Indexer-specific stats
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Stats"
+
+  /health:
+    get:
+      summary: Health check
+      responses:
+        "200":
+          description: Server health
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+
+components:
+  schemas:
+    Asset:
+      type: object
+      properties:
+        id: { type: string }
+        collectionId: { type: string }
+        owner: { type: string }
+        tokenUri: { type: string }
+        mintedAtBlock: { type: integer }
+        indexerSource: { type: string }
+    Collection:
+      type: object
+      properties:
+        id: { type: string }
+        creator: { type: string }
+        metadataUri: { type: string }
+        createdAtBlock: { type: integer }
+        indexerSource: { type: string }
+        assetCount: { type: integer }
+    Transfer:
+      type: object
+      properties:
+        id: { type: string }
+        tokenId: { type: string }
+        from: { type: string }
+        to: { type: string }
+        block: { type: integer }
+        indexerSource: { type: string }
+    Stats:
+      type: object
+      properties:
+        totalAssets: { type: integer }
+        totalCollections: { type: integer }
+        totalTransfers: { type: integer }
+    PaginatedAssets:
+      type: object
+      properties:
+        data:
+          type: array
+          items: { $ref: "#/components/schemas/Asset" }
+        pagination:
+          type: object
+          properties:
+            total: { type: integer }
+            limit: { type: integer }
+            offset: { type: integer }
+            hasMore: { type: boolean }
+    PaginatedCollections:
+      type: object
+      properties:
+        data:
+          type: array
+          items: { $ref: "#/components/schemas/Collection" }
+        pagination:
+          type: object
+          properties:
+            total: { type: integer }
+            limit: { type: integer }
+            offset: { type: integer }
+            hasMore: { type: boolean }
+    PaginatedTransfers:
+      type: object
+      properties:
+        data:
+          type: array
+          items: { $ref: "#/components/schemas/Transfer" }
+        pagination:
+          type: object
+          properties:
+            total: { type: integer }
+            limit: { type: integer }
+            offset: { type: integer }
+            hasMore: { type: boolean }

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "prepare": "apibara prepare",
     "dev:dapp": "dotenv -e .env.dapp -- apibara dev --indexers medialano-dapp --preset=sepolia",
     "dev:mipp:mainnet": "dotenv -e .env.mipp -- apibara dev --indexers medialano-mipp-mainnet --preset",
-    "api:dev": "dotenv -e .env ts-node-dev src/server.ts",
+    "api:dev": "dotenv -e .env tsx watch src/server.ts",
     "build:indexer": "apibara build",
     "build:api": "tsc --project tsconfig.api.json",
     "build:deployment": "tsc --project tsconfig.deployment.json",
@@ -15,7 +15,7 @@
     "start:indexer:mipp": "apibara start --indexer medialano-mipp-mainnet --preset",
     "start:indexer:dapp:web": "node dist/deployment/deployment-service.js dapp",
     "start:indexer:mipp:web": "node dist/depoyment/deployment-service.js mipp",
-    "start:api:deploy": "pnpm run drizzle:generate && pnpm run drizzle:push && pnpm run build:api && node dist/api/server.js",
+    "start:api:deploy": "pnpm run drizzle:generate && pnpm run drizzle:push && pnpm run build:api && node dist/api/src/server.js",
     "drizzle:generate": "drizzle-kit generate",
     "drizzle:migrate": "drizzle-kit migrate",
     "drizzle:push": "drizzle-kit push",
@@ -28,6 +28,7 @@
     "@apibara/protocol": "next",
     "@apibara/starknet": "next",
     "@electric-sql/pglite": "^0.2.17",
+    "@fastify/cors": "^11.1.0",
     "apibara": "next",
     "drizzle-kit": "^0.29.0",
     "drizzle-orm": "^0.40.1",
@@ -39,6 +40,7 @@
     "@types/node": "^20.5.2",
     "@types/pg": "^8.11.10",
     "dotenv-cli": "^10.0.0",
+    "tsx": "^4.20.5",
     "typescript": "^5.6.2"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,12 +29,15 @@
     "@apibara/starknet": "next",
     "@electric-sql/pglite": "^0.2.17",
     "@fastify/cors": "^11.1.0",
+    "@fastify/swagger": "^9.5.1",
+    "@fastify/swagger-ui": "^5.2.3",
     "apibara": "next",
     "drizzle-kit": "^0.29.0",
     "drizzle-orm": "^0.40.1",
     "fastify": "^5.5.0",
     "pg": "^8.13.1",
-    "starknet": "^7.6.4"
+    "starknet": "^7.6.4",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@types/node": "^20.5.2",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@fastify/cors':
         specifier: ^11.1.0
         version: 11.1.0
+      '@fastify/swagger':
+        specifier: ^9.5.1
+        version: 9.5.1
+      '@fastify/swagger-ui':
+        specifier: ^5.2.3
+        version: 5.2.3
       apibara:
         specifier: next
         version: 2.1.0-beta.39(rollup@4.49.0)(typescript@5.9.2)(vitest@1.6.1(@types/node@20.19.11))
@@ -41,6 +47,9 @@ importers:
       starknet:
         specifier: ^7.6.4
         version: 7.6.4
+      yaml:
+        specifier: ^2.8.1
+        version: 2.8.1
     devDependencies:
       '@types/node':
         specifier: ^20.5.2
@@ -51,15 +60,6 @@ importers:
       dotenv-cli:
         specifier: ^10.0.0
         version: 10.0.0
-      fastify-tsconfig:
-        specifier: ^3.0.0
-        version: 3.0.0
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.11)(typescript@5.9.2)
-      ts-node-dev:
-        specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.19.11)(typescript@5.9.2)
       tsx:
         specifier: ^4.20.5
         version: 4.20.5
@@ -169,10 +169,6 @@ packages:
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
-
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -761,6 +757,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
 
@@ -782,6 +781,18 @@ packages:
   '@fastify/proxy-addr@5.0.0':
     resolution: {integrity: sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==}
 
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@8.2.0':
+    resolution: {integrity: sha512-PejC/DtT7p1yo3p+W7LiUtLMsV8fEvxAK15sozHy9t8kwo5r0uLYmhV/inURmGz1SkHZFz/8CNtHLPyhKcx4SQ==}
+
+  '@fastify/swagger-ui@5.2.3':
+    resolution: {integrity: sha512-e7ivEJi9EpFcxTONqICx4llbpB2jmlI+LI1NQ/mR7QGQnyDOqZybPK572zJtcdHZW4YyYTBHcP3a03f1pOh0SA==}
+
+  '@fastify/swagger@9.5.1':
+    resolution: {integrity: sha512-EGjYLA7vDmCPK7XViAYMF6y4+K3XUy5soVTVxsyXolNe/Svb4nFQxvtuQvvoQb2Gzc9pxiF3+ZQN/iZDHhKtTg==}
+
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
     engines: {node: '>=12.10.0'}
@@ -790,6 +801,18 @@ packages:
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -811,11 +834,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1110,18 +1134,6 @@ packages:
   '@ts-morph/common@0.26.1':
     resolution: {integrity: sha512-Sn28TGl/4cFpcM+jwsH1wLncYq3FtN/BIpem+HOygfBWPT5pAeS5dB4VFVzV8FbnOKHpDLZmvAl4AjPEev5idA==}
 
-  '@tsconfig/node10@1.0.11':
-    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
@@ -1133,12 +1145,6 @@ packages:
 
   '@types/pg@8.15.5':
     resolution: {integrity: sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==}
-
-  '@types/strip-bom@3.0.0':
-    resolution: {integrity: sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==}
-
-  '@types/strip-json-comments@0.0.30':
-    resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
 
   '@valibot/to-json-schema@1.0.0-beta.4':
     resolution: {integrity: sha512-wXBdCyoqec+NLCl5ihitXzZXD4JAjPK3+HfskSXzfhiNFvKje0A/v1LygqKidUgIbaJtREmq/poJGbaS/0MKuQ==}
@@ -1205,6 +1211,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.0:
+    resolution: {integrity: sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1212,6 +1222,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
 
   ansicolors@0.3.2:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
@@ -1223,9 +1237,6 @@ packages:
   apibara@2.1.0-beta.39:
     resolution: {integrity: sha512-LbtA/s7W41PyXmL7tIOWr0bM/AQ9BlwFiT8MAapfhDZKrbRrb+4T2ieUxJnGqUJI/bKq1E/DfjS4RgATOo5LmQ==}
     hasBin: true
-
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -1243,9 +1254,6 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -1317,9 +1325,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -1327,15 +1332,16 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
-
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1357,6 +1363,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1367,10 +1377,6 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
 
   dotenv-cli@10.0.0:
     resolution: {integrity: sha512-lnOnttzfrzkRx2echxJHQRB6vOAMSCzzZg79IxpC00tU42wZPuZkQxNNrrwVAxaQZIIh001l4PxVlCrBxngBzA==}
@@ -1481,14 +1487,17 @@ packages:
       sqlite3:
         optional: true
 
-  dynamic-dedupe@0.3.0:
-    resolution: {integrity: sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==}
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   electron-to-chromium@1.5.211:
     resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -1518,6 +1527,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -1563,10 +1575,6 @@ packages:
   fastify-plugin@5.0.1:
     resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
 
-  fastify-tsconfig@3.0.0:
-    resolution: {integrity: sha512-TxFM9+MUUM2Ub6chZbP5sPNUFaPWA86kHU0VRd4o9OP6PBP92cj9c4/IEsnLoVHcLgrgXf2GUXWUzkJAO9iKFQ==}
-    engines: {node: '>=20.0.0'}
-
   fastify@5.5.0:
     resolution: {integrity: sha512-ZWSWlzj3K/DcULCnCjEiC2zn2FBPdlZsSA/pnPa/dbUfLvxkD/Nqmb0XXMXLrWkeM4uQPUvjdJpwtXmTfriXqw==}
 
@@ -1581,6 +1589,10 @@ packages:
     resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
     engines: {node: '>=20'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -1593,16 +1605,10 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1630,27 +1636,24 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1662,10 +1665,6 @@ packages:
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
-
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1695,6 +1694,10 @@ packages:
     peerDependencies:
       ws: '*'
 
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -1716,6 +1719,10 @@ packages:
 
   json-schema-ref-resolver@2.0.1:
     resolution: {integrity: sha512-HG0SIB9X4J8bwbxCbnd5FfPEbcXAJYTi1pBJeP/QPON+w8ovSME8iRG+ElHNxZNX2Qh6eYn1GdzJFS4cDFfx0Q==}
+
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1758,14 +1765,15 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
-
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -1778,12 +1786,18 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -1799,6 +1813,10 @@ packages:
   minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -1852,12 +1870,12 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   ox@0.9.1:
     resolution: {integrity: sha512-NVI0cajROntJWtFnxZQ1aXDVy+c6DLEXJ3wwON48CgbPhmMJrpRTfVbuppR+47RmXm3lZ/uMaKiFSkLdAO1now==}
@@ -1871,15 +1889,14 @@ packages:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1889,8 +1906,9 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
-  path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2042,11 +2060,6 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  resolve@1.22.10:
-    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
@@ -2057,11 +2070,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rolldown@1.0.0-beta.3:
     resolution: {integrity: sha512-DBpF1K8tSwU/0dQ7zL9BYcje0/GjO5lgfdEW0rHHFfGjGDh8TBVNlokfEXtdt/IoJOiTdtySfsrgarLJkZmZTQ==}
@@ -2079,6 +2087,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.0.0:
     resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
@@ -2104,6 +2115,9 @@ packages:
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2148,6 +2162,10 @@ packages:
     resolution: {integrity: sha512-FB20IaLCDbh/XomkB+19f5jmNxG+RzNdRO7QUhm7nfH81UPIt2C/MyWAlHCYkbv2wznSEb73wpxbp9tytokTgQ==}
     engines: {node: '>=22'}
 
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
@@ -2155,28 +2173,24 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
-
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
@@ -2207,9 +2221,9 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   ts-error@1.0.6:
     resolution: {integrity: sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==}
@@ -2219,34 +2233,6 @@ packages:
 
   ts-morph@25.0.1:
     resolution: {integrity: sha512-QJEiTdnz1YjrB3JFhd626gX4rKHDLSjSVMvGGG4v7ONc3RBwa0Eei98G9AT9uNFDMtV54JyuXsFeC+OH0n6bXQ==}
-
-  ts-node-dev@2.0.0:
-    resolution: {integrity: sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    peerDependencies:
-      node-notifier: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
-  tsconfig@7.0.0:
-    resolution: {integrity: sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2291,9 +2277,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   valibot@1.0.0-beta.12:
     resolution: {integrity: sha512-j3WIxJ0pmUFMfdfUECn3YnZPYOiG0yHYcFEa/+RVgo0I+MXE3ToLt7gNRLtY5pwGfgNmsmhenGZfU5suu9ijUA==}
@@ -2389,8 +2372,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -2418,6 +2402,11 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yaml@2.8.1:
+    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -2425,10 +2414,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
 
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
@@ -2605,10 +2590,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -2922,6 +2903,8 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.2':
     dependencies:
       ajv: 8.17.1
@@ -2950,6 +2933,41 @@ snapshots:
       '@fastify/forwarded': 3.0.0
       ipaddr.js: 2.2.0
 
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.0
+      mime: 3.0.0
+
+  '@fastify/static@8.2.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 0.5.4
+      fastify-plugin: 5.0.1
+      fastq: 1.19.1
+      glob: 11.0.3
+
+  '@fastify/swagger-ui@5.2.3':
+    dependencies:
+      '@fastify/static': 8.2.0
+      fastify-plugin: 5.0.1
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.1
+
+  '@fastify/swagger@9.5.1':
+    dependencies:
+      fastify-plugin: 5.0.1
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@grpc/grpc-js@1.13.4':
     dependencies:
       '@grpc/proto-loader': 0.7.15
@@ -2961,6 +2979,21 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
+
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -2985,12 +3018,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jridgewell/trace-mapping@0.3.9':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@lukeed/ms@2.0.2': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3210,14 +3240,6 @@ snapshots:
       minimatch: 9.0.5
       path-browserify: 1.0.1
 
-  '@tsconfig/node10@1.0.11': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
-
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
@@ -3234,10 +3256,6 @@ snapshots:
       '@types/node': 20.19.11
       pg-protocol: 1.10.3
       pg-types: 2.2.0
-
-  '@types/strip-bom@3.0.0': {}
-
-  '@types/strip-json-comments@0.0.30': {}
 
   '@valibot/to-json-schema@1.0.0-beta.4(valibot@1.0.0-beta.12(typescript@5.9.2))':
     dependencies:
@@ -3306,11 +3324,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.1: {}
 
   ansicolors@0.3.2: {}
 
@@ -3356,8 +3378,6 @@ snapshots:
       - vitest
       - zod
 
-  arg@4.1.3: {}
-
   assertion-error@1.1.0: {}
 
   atomic-sleep@1.0.0: {}
@@ -3370,11 +3390,6 @@ snapshots:
   balanced-match@1.0.2: {}
 
   binary-extensions@2.3.0: {}
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   brace-expansion@2.0.2:
     dependencies:
@@ -3465,17 +3480,17 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  concat-map@0.0.1: {}
-
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   convert-source-map@2.0.0: {}
 
   cookie@1.0.2: {}
-
-  create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3493,13 +3508,13 @@ snapshots:
 
   defu@6.1.4: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
 
   diff-sequences@29.6.3: {}
-
-  diff@4.0.2: {}
 
   dotenv-cli@10.0.0:
     dependencies:
@@ -3532,13 +3547,13 @@ snapshots:
       '@types/pg': 8.15.5
       pg: 8.16.3
 
-  dynamic-dedupe@0.3.0:
-    dependencies:
-      xtend: 4.0.2
+  eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.211: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
@@ -3655,6 +3670,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   esprima@4.0.1: {}
 
   estree-walker@2.0.2: {}
@@ -3708,8 +3725,6 @@ snapshots:
 
   fastify-plugin@5.0.1: {}
 
-  fastify-tsconfig@3.0.0: {}
-
   fastify@5.5.0:
     dependencies:
       '@fastify/ajv-compiler': 4.0.2
@@ -3742,6 +3757,11 @@ snapshots:
       fast-querystring: 1.1.2
       safe-regex2: 5.0.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -3758,12 +3778,8 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
-
-  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -3791,29 +3807,28 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@7.2.3:
+  glob@11.0.3:
     dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
 
   graceful-fs@4.2.11: {}
 
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
   hookable@5.5.3: {}
 
-  human-signals@5.0.0: {}
-
-  inflight@1.0.6:
+  http-errors@2.0.0:
     dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  human-signals@5.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -3822,10 +3837,6 @@ snapshots:
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
-
-  is-core-module@2.16.1:
-    dependencies:
-      hasown: 2.0.2
 
   is-extglob@2.1.1: {}
 
@@ -3845,6 +3856,10 @@ snapshots:
     dependencies:
       ws: 8.18.3
 
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   jiti@1.21.7: {}
 
   jiti@2.5.1: {}
@@ -3858,6 +3873,14 @@ snapshots:
   json-schema-ref-resolver@2.0.1:
     dependencies:
       dequal: 2.0.3
+
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.1
+      fast-uri: 3.1.0
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   json-schema-traverse@1.0.0: {}
 
@@ -3896,6 +3919,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  lru-cache@11.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3903,8 +3928,6 @@ snapshots:
   magic-string@0.30.18:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  make-error@1.3.6: {}
 
   merge-stream@2.0.0: {}
 
@@ -3915,11 +3938,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime@3.0.0: {}
+
   mimic-fn@4.0.0: {}
 
-  minimatch@3.1.2:
+  minimatch@10.0.3:
     dependencies:
-      brace-expansion: 1.1.12
+      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@9.0.5:
     dependencies:
@@ -3932,6 +3957,8 @@ snapshots:
       yallist: 4.0.0
 
   minipass@5.0.0: {}
+
+  minipass@7.1.2: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -3984,13 +4011,11 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  openapi-types@12.1.3: {}
 
   ox@0.9.1(typescript@5.9.2):
     dependencies:
@@ -4011,17 +4036,20 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.1
 
+  package-json-from-dist@1.0.1: {}
+
   pako@2.1.0: {}
 
   path-browserify@1.0.1: {}
-
-  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
 
-  path-parse@1.0.7: {}
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.2.1
+      minipass: 7.1.2
 
   pathe@1.1.2: {}
 
@@ -4175,21 +4203,11 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  resolve@1.22.10:
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
   ret@0.5.0: {}
 
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
-
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
 
   rolldown@1.0.0-beta.3(typescript@5.9.2):
     dependencies:
@@ -4242,6 +4260,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safe-regex2@5.0.0:
     dependencies:
       ret: 0.5.0
@@ -4257,6 +4277,8 @@ snapshots:
   semver@7.7.2: {}
 
   set-cookie-parser@2.7.1: {}
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4300,6 +4322,8 @@ snapshots:
       pako: 2.1.0
       ts-mixer: 6.0.4
 
+  statuses@2.0.1: {}
+
   std-env@3.9.0: {}
 
   string-width@4.2.3:
@@ -4308,21 +4332,25 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-bom@3.0.0: {}
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.2.0
 
   strip-final-newline@3.0.0: {}
-
-  strip-json-comments@2.0.1: {}
 
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
-
-  supports-preserve-symlinks-flag@1.0.0: {}
 
   tar@6.2.1:
     dependencies:
@@ -4351,7 +4379,7 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
-  tree-kill@1.2.2: {}
+  toidentifier@1.0.1: {}
 
   ts-error@1.0.6: {}
 
@@ -4361,49 +4389,6 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.26.1
       code-block-writer: 13.0.3
-
-  ts-node-dev@2.0.0(@types/node@20.19.11)(typescript@5.9.2):
-    dependencies:
-      chokidar: 3.6.0
-      dynamic-dedupe: 0.3.0
-      minimist: 1.2.8
-      mkdirp: 1.0.4
-      resolve: 1.22.10
-      rimraf: 2.7.1
-      source-map-support: 0.5.21
-      tree-kill: 1.2.2
-      ts-node: 10.9.2(@types/node@20.19.11)(typescript@5.9.2)
-      tsconfig: 7.0.0
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-
-  ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.11
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
-  tsconfig@7.0.0:
-    dependencies:
-      '@types/strip-bom': 3.0.0
-      '@types/strip-json-comments': 0.0.30
-      strip-bom: 3.0.0
-      strip-json-comments: 2.0.1
 
   tslib@2.8.1: {}
 
@@ -4456,8 +4441,6 @@ snapshots:
       browserslist: 4.25.4
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  v8-compile-cache-lib@3.0.1: {}
 
   valibot@1.0.0-beta.12(typescript@5.9.2):
     optionalDependencies:
@@ -4558,7 +4541,11 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrappy@1.0.2: {}
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
 
   ws@8.18.3: {}
 
@@ -4569,6 +4556,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yaml@2.8.1: {}
 
   yargs-parser@21.1.1: {}
 
@@ -4581,7 +4570,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yn@3.1.1: {}
 
   yocto-queue@1.2.1: {}

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@electric-sql/pglite':
         specifier: ^0.2.17
         version: 0.2.17
+      '@fastify/cors':
+        specifier: ^11.1.0
+        version: 11.1.0
       apibara:
         specifier: next
         version: 2.1.0-beta.39(rollup@4.49.0)(typescript@5.9.2)(vitest@1.6.1(@types/node@20.19.11))
@@ -48,6 +51,18 @@ importers:
       dotenv-cli:
         specifier: ^10.0.0
         version: 10.0.0
+      fastify-tsconfig:
+        specifier: ^3.0.0
+        version: 3.0.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.11)(typescript@5.9.2)
+      ts-node-dev:
+        specifier: ^2.0.0
+        version: 2.0.0(@types/node@20.19.11)(typescript@5.9.2)
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
       typescript:
         specifier: ^5.6.2
         version: 5.9.2
@@ -155,6 +170,10 @@ packages:
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
@@ -190,6 +209,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -205,6 +230,12 @@ packages:
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -226,6 +257,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -241,6 +278,12 @@ packages:
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -262,6 +305,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -277,6 +326,12 @@ packages:
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -298,6 +353,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -313,6 +374,12 @@ packages:
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -334,6 +401,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -349,6 +422,12 @@ packages:
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -370,6 +449,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -385,6 +470,12 @@ packages:
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -406,6 +497,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -421,6 +518,12 @@ packages:
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -442,6 +545,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -457,6 +566,12 @@ packages:
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -478,6 +593,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.18.20':
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
@@ -495,6 +622,18 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
@@ -514,6 +653,18 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.18.20':
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
@@ -529,6 +680,12 @@ packages:
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -550,6 +707,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.18.20':
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
@@ -565,6 +728,12 @@ packages:
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
@@ -586,8 +755,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
+
+  '@fastify/cors@11.1.0':
+    resolution: {integrity: sha512-sUw8ed8wP2SouWZTIbA7V2OQtMNpLj2W6qJOYhNdcmINTu6gsxVYXjQiM9mdi8UUDlcoDDJ/W2syPo1WB2QjYA==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -632,6 +810,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -929,6 +1110,18 @@ packages:
   '@ts-morph/common@0.26.1':
     resolution: {integrity: sha512-Sn28TGl/4cFpcM+jwsH1wLncYq3FtN/BIpem+HOygfBWPT5pAeS5dB4VFVzV8FbnOKHpDLZmvAl4AjPEev5idA==}
 
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
@@ -940,6 +1133,12 @@ packages:
 
   '@types/pg@8.15.5':
     resolution: {integrity: sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==}
+
+  '@types/strip-bom@3.0.0':
+    resolution: {integrity: sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==}
+
+  '@types/strip-json-comments@0.0.30':
+    resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
 
   '@valibot/to-json-schema@1.0.0-beta.4':
     resolution: {integrity: sha512-wXBdCyoqec+NLCl5ihitXzZXD4JAjPK3+HfskSXzfhiNFvKje0A/v1LygqKidUgIbaJtREmq/poJGbaS/0MKuQ==}
@@ -1025,6 +1224,9 @@ packages:
     resolution: {integrity: sha512-LbtA/s7W41PyXmL7tIOWr0bM/AQ9BlwFiT8MAapfhDZKrbRrb+4T2ieUxJnGqUJI/bKq1E/DfjS4RgATOo5LmQ==}
     hasBin: true
 
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
@@ -1041,6 +1243,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -1112,6 +1317,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -1125,6 +1333,9 @@ packages:
   cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1156,6 +1367,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
 
   dotenv-cli@10.0.0:
     resolution: {integrity: sha512-lnOnttzfrzkRx2echxJHQRB6vOAMSCzzZg79IxpC00tU42wZPuZkQxNNrrwVAxaQZIIh001l4PxVlCrBxngBzA==}
@@ -1266,6 +1481,9 @@ packages:
       sqlite3:
         optional: true
 
+  dynamic-dedupe@0.3.0:
+    resolution: {integrity: sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==}
+
   electron-to-chromium@1.5.211:
     resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
 
@@ -1290,6 +1508,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -1337,6 +1560,13 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fastify-plugin@5.0.1:
+    resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
+
+  fastify-tsconfig@3.0.0:
+    resolution: {integrity: sha512-TxFM9+MUUM2Ub6chZbP5sPNUFaPWA86kHU0VRd4o9OP6PBP92cj9c4/IEsnLoVHcLgrgXf2GUXWUzkJAO9iKFQ==}
+    engines: {node: '>=20.0.0'}
+
   fastify@5.5.0:
     resolution: {integrity: sha512-ZWSWlzj3K/DcULCnCjEiC2zn2FBPdlZsSA/pnPa/dbUfLvxkD/Nqmb0XXMXLrWkeM4uQPUvjdJpwtXmTfriXqw==}
 
@@ -1363,10 +1593,16 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1394,8 +1630,16 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -1404,6 +1648,13 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ipaddr.js@2.2.0:
     resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
     engines: {node: '>= 10'}
@@ -1411,6 +1662,10 @@ packages:
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1509,6 +1764,9 @@ packages:
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
 
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -1523,6 +1781,9 @@ packages:
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -1591,6 +1852,9 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -1613,6 +1877,10 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1620,6 +1888,9 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -1771,6 +2042,11 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
@@ -1781,6 +2057,11 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rolldown@1.0.0-beta.3:
     resolution: {integrity: sha512-DBpF1K8tSwU/0dQ7zL9BYcje0/GjO5lgfdEW0rHHFfGjGDh8TBVNlokfEXtdt/IoJOiTdtySfsrgarLJkZmZTQ==}
@@ -1878,12 +2159,24 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
@@ -1914,6 +2207,10 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-error@1.0.6:
     resolution: {integrity: sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==}
 
@@ -1923,8 +2220,41 @@ packages:
   ts-morph@25.0.1:
     resolution: {integrity: sha512-QJEiTdnz1YjrB3JFhd626gX4rKHDLSjSVMvGGG4v7ONc3RBwa0Eei98G9AT9uNFDMtV54JyuXsFeC+OH0n6bXQ==}
 
+  ts-node-dev@2.0.0:
+    resolution: {integrity: sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+    peerDependencies:
+      node-notifier: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  tsconfig@7.0.0:
+    resolution: {integrity: sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
@@ -1961,6 +2291,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   valibot@1.0.0-beta.12:
     resolution: {integrity: sha512-j3WIxJ0pmUFMfdfUECn3YnZPYOiG0yHYcFEa/+RVgo0I+MXE3ToLt7gNRLtY5pwGfgNmsmhenGZfU5suu9ijUA==}
@@ -2056,6 +2389,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
@@ -2089,6 +2425,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
@@ -2266,6 +2606,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@drizzle-team/brocli@0.10.2': {}
 
   '@electric-sql/pglite@0.2.17': {}
@@ -2302,6 +2646,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
@@ -2309,6 +2656,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -2320,6 +2670,9 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
@@ -2327,6 +2680,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -2338,6 +2694,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
@@ -2345,6 +2704,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -2356,6 +2718,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
@@ -2363,6 +2728,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -2374,6 +2742,9 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
@@ -2381,6 +2752,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -2392,6 +2766,9 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
@@ -2399,6 +2776,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -2410,6 +2790,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
@@ -2417,6 +2800,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -2428,6 +2814,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
@@ -2435,6 +2824,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -2446,6 +2838,12 @@ snapshots:
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
@@ -2453,6 +2851,12 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -2464,6 +2868,12 @@ snapshots:
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
@@ -2471,6 +2881,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
@@ -2482,6 +2895,9 @@ snapshots:
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
@@ -2489,6 +2905,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.9':
     optional: true
 
   '@esbuild/win32-x64@0.18.20':
@@ -2500,11 +2919,19 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@esbuild/win32-x64@0.25.9':
+    optional: true
+
   '@fastify/ajv-compiler@4.0.2':
     dependencies:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       fast-uri: 3.1.0
+
+  '@fastify/cors@11.1.0':
+    dependencies:
+      fastify-plugin: 5.0.1
+      toad-cache: 3.7.0
 
   '@fastify/error@4.2.0': {}
 
@@ -2554,6 +2981,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.30':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2778,6 +3210,14 @@ snapshots:
       minimatch: 9.0.5
       path-browserify: 1.0.1
 
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
@@ -2794,6 +3234,10 @@ snapshots:
       '@types/node': 20.19.11
       pg-protocol: 1.10.3
       pg-types: 2.2.0
+
+  '@types/strip-bom@3.0.0': {}
+
+  '@types/strip-json-comments@0.0.30': {}
 
   '@valibot/to-json-schema@1.0.0-beta.4(valibot@1.0.0-beta.12(typescript@5.9.2))':
     dependencies:
@@ -2912,6 +3356,8 @@ snapshots:
       - vitest
       - zod
 
+  arg@4.1.3: {}
+
   assertion-error@1.1.0: {}
 
   atomic-sleep@1.0.0: {}
@@ -2924,6 +3370,11 @@ snapshots:
   balanced-match@1.0.2: {}
 
   binary-extensions@2.3.0: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@2.0.2:
     dependencies:
@@ -3014,6 +3465,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  concat-map@0.0.1: {}
+
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
@@ -3021,6 +3474,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.0.2: {}
+
+  create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3043,6 +3498,8 @@ snapshots:
   destr@2.0.5: {}
 
   diff-sequences@29.6.3: {}
+
+  diff@4.0.2: {}
 
   dotenv-cli@10.0.0:
     dependencies:
@@ -3074,6 +3531,10 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.15.5
       pg: 8.16.3
+
+  dynamic-dedupe@0.3.0:
+    dependencies:
+      xtend: 4.0.2
 
   electron-to-chromium@1.5.211: {}
 
@@ -3163,6 +3624,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
+
   escalade@3.2.0: {}
 
   esprima@4.0.1: {}
@@ -3216,6 +3706,10 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fastify-plugin@5.0.1: {}
+
+  fastify-tsconfig@3.0.0: {}
+
   fastify@5.5.0:
     dependencies:
       '@fastify/ajv-compiler': 4.0.2
@@ -3264,8 +3758,12 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -3293,17 +3791,41 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   graceful-fs@4.2.11: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hookable@5.5.3: {}
 
   human-signals@5.0.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
 
   ipaddr.js@2.2.0: {}
 
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
 
   is-extglob@2.1.1: {}
 
@@ -3382,6 +3904,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  make-error@1.3.6: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -3392,6 +3916,10 @@ snapshots:
       picomatch: 2.3.1
 
   mimic-fn@4.0.0: {}
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
 
   minimatch@9.0.5:
     dependencies:
@@ -3456,6 +3984,10 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -3483,9 +4015,13 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-is-absolute@1.0.1: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-parse@1.0.7: {}
 
   pathe@1.1.2: {}
 
@@ -3639,11 +4175,21 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   ret@0.5.0: {}
 
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
 
   rolldown@1.0.0-beta.3(typescript@5.9.2):
     dependencies:
@@ -3766,11 +4312,17 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-bom@3.0.0: {}
+
   strip-final-newline@3.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   tar@6.2.1:
     dependencies:
@@ -3799,6 +4351,8 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  tree-kill@1.2.2: {}
+
   ts-error@1.0.6: {}
 
   ts-mixer@6.0.4: {}
@@ -3808,7 +4362,57 @@ snapshots:
       '@ts-morph/common': 0.26.1
       code-block-writer: 13.0.3
 
+  ts-node-dev@2.0.0(@types/node@20.19.11)(typescript@5.9.2):
+    dependencies:
+      chokidar: 3.6.0
+      dynamic-dedupe: 0.3.0
+      minimist: 1.2.8
+      mkdirp: 1.0.4
+      resolve: 1.22.10
+      rimraf: 2.7.1
+      source-map-support: 0.5.21
+      tree-kill: 1.2.2
+      ts-node: 10.9.2(@types/node@20.19.11)(typescript@5.9.2)
+      tsconfig: 7.0.0
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+
+  ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.11
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  tsconfig@7.0.0:
+    dependencies:
+      '@types/strip-bom': 3.0.0
+      '@types/strip-json-comments': 0.0.30
+      strip-bom: 3.0.0
+      strip-json-comments: 2.0.1
+
   tslib@2.8.1: {}
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-detect@4.1.0: {}
 
@@ -3852,6 +4456,8 @@ snapshots:
       browserslist: 4.25.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  v8-compile-cache-lib@3.0.1: {}
 
   valibot@1.0.0-beta.12(typescript@5.9.2):
     optionalDependencies:
@@ -3952,6 +4558,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrappy@1.0.2: {}
+
   ws@8.18.3: {}
 
   xtend@4.0.2: {}
@@ -3973,5 +4581,7 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yn@3.1.1: {}
 
   yocto-queue@1.2.1: {}

--- a/backend/src/routes/assets.ts
+++ b/backend/src/routes/assets.ts
@@ -1,0 +1,223 @@
+import { FastifyInstance, FastifyRequest} from 'fastify';
+
+import { assets, collections,INDEXER_SOURCES } from 'lib/schema';
+import { eq, and, desc, asc, like, count } from 'drizzle-orm';
+import { db } from 'lib/db.api';
+
+interface GetAssetsByOwnerParams {
+  owner: string;
+}
+
+interface GetAssetsByOwnerQuery {
+  indexerSource?: keyof typeof INDEXER_SOURCES;
+  collectionId?: string;
+  limit?: number;
+  offset?: number;
+  sortBy?: 'mintedAtBlock' | 'id';
+  sortOrder?: 'asc' | 'desc';
+}
+
+export async function assetsRoutes(fastify: FastifyInstance) {
+  // Get assets by owner
+  fastify.get<{
+    Params: GetAssetsByOwnerParams;
+    Querystring: GetAssetsByOwnerQuery;
+  }>('/assets/owner/:owner', async (request, reply) => {
+    try {
+      const { owner } = request.params;
+      const { 
+        indexerSource, 
+        collectionId, 
+        limit = 20, 
+        offset = 0, 
+        sortBy = 'mintedAtBlock', 
+        sortOrder = 'desc' 
+      } = request.query;
+
+      const conditions = [eq(assets.owner, owner)];
+      
+      if (indexerSource) {
+        conditions.push(eq(assets.indexerSource, INDEXER_SOURCES[indexerSource]));
+      }
+      
+      if (collectionId) {
+        conditions.push(eq(assets.collectionId, collectionId));
+      }
+
+      const orderBy = sortOrder === 'desc' 
+        ? desc(assets[sortBy]) 
+        : asc(assets[sortBy]);
+
+      const [userAssets, totalCount] = await Promise.all([
+        db
+          .select({
+            id: assets.id,
+            collectionId: assets.collectionId,
+            owner: assets.owner,
+            tokenUri: assets.tokenUri,
+            mintedAtBlock: assets.mintedAtBlock,
+            indexerSource: assets.indexerSource,
+            collection: {
+              id: collections.id,
+              creator: collections.creator,
+              metadataUri: collections.metadataUri,
+              createdAtBlock: collections.createdAtBlock,
+              indexerSource: collections.indexerSource
+            }
+          })
+          .from(assets)
+          .leftJoin(collections, eq(assets.collectionId, collections.id))
+          .where(and(...conditions))
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset),
+        
+        db
+          .select({ count: count() })
+          .from(assets)
+          .where(and(...conditions))
+          .then(result => result[0].count)
+      ]);
+
+      reply.send({
+        data: userAssets,
+        pagination: {
+          total: totalCount,
+          limit,
+          offset,
+          hasMore: offset + limit < totalCount
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get single asset by ID
+  fastify.get<{ Params: { id: string } }>('/assets/:id', async (request, reply) => {
+    try {
+      const { id } = request.params;
+
+      const asset = await db
+        .select({
+          id: assets.id,
+          collectionId: assets.collectionId,
+          owner: assets.owner,
+          tokenUri: assets.tokenUri,
+          mintedAtBlock: assets.mintedAtBlock,
+          indexerSource: assets.indexerSource,
+          collection: {
+            id: collections.id,
+            creator: collections.creator,
+            metadataUri: collections.metadataUri,
+            createdAtBlock: collections.createdAtBlock,
+            indexerSource: collections.indexerSource
+          }
+        })
+        .from(assets)
+        .leftJoin(collections, eq(assets.collectionId, collections.id))
+        .where(eq(assets.id, id))
+        .limit(1);
+
+      if (asset.length === 0) {
+        reply.status(404).send({ error: 'Asset not found' });
+        return;
+      }
+
+      reply.send({ data: asset[0] });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get all assets with filtering
+  fastify.get('/assets', async (request: FastifyRequest<{
+    Querystring: {
+      indexerSource?: keyof typeof INDEXER_SOURCES;
+      collectionId?: string;
+      search?: string;
+      limit?: number;
+      offset?: number;
+      sortBy?: 'mintedAtBlock' | 'id';
+      sortOrder?: 'asc' | 'desc';
+    };
+  }>, reply) => {
+    try {
+      const { 
+        indexerSource, 
+        collectionId, 
+        search,
+        limit = 20, 
+        offset = 0, 
+        sortBy = 'mintedAtBlock', 
+        sortOrder = 'desc' 
+      } = request.query;
+
+      const conditions = [];
+      
+      if (indexerSource) {
+        conditions.push(eq(assets.indexerSource, INDEXER_SOURCES[indexerSource]));
+      }
+      
+      if (collectionId) {
+        conditions.push(eq(assets.collectionId, collectionId));
+      }
+
+      if (search) {
+        conditions.push(like(assets.id, `%${search}%`));
+      }
+
+      const orderBy = sortOrder === 'desc' 
+        ? desc(assets[sortBy]) 
+        : asc(assets[sortBy]);
+
+      const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+      const [allAssets, totalCount] = await Promise.all([
+        db
+          .select({
+            id: assets.id,
+            collectionId: assets.collectionId,
+            owner: assets.owner,
+            tokenUri: assets.tokenUri,
+            mintedAtBlock: assets.mintedAtBlock,
+            indexerSource: assets.indexerSource,
+            collection: {
+              id: collections.id,
+              creator: collections.creator,
+              metadataUri: collections.metadataUri,
+              createdAtBlock: collections.createdAtBlock,
+              indexerSource: collections.indexerSource
+            }
+          })
+          .from(assets)
+          .leftJoin(collections, eq(assets.collectionId, collections.id))
+          .where(whereClause)
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset),
+        
+        db
+          .select({ count: count() })
+          .from(assets)
+          .where(whereClause)
+          .then(result => result[0].count)
+      ]);
+
+      reply.send({
+        data: allAssets,
+        pagination: {
+          total: totalCount,
+          limit,
+          offset,
+          hasMore: offset + limit < totalCount
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+}

--- a/backend/src/routes/collection.ts
+++ b/backend/src/routes/collection.ts
@@ -1,0 +1,282 @@
+import { FastifyInstance } from 'fastify';
+import { db } from 'lib/db.api';
+import { assets, collections, INDEXER_SOURCES } from 'lib/schema';
+import { eq, and, desc, asc, like, count } from 'drizzle-orm';
+
+interface GetCollectionsByCreatorParams {
+  creator: string;
+}
+
+interface GetCollectionsByCreatorQuery {
+  indexerSource?: keyof typeof INDEXER_SOURCES;
+  limit?: number;
+  offset?: number;
+  sortBy?: 'createdAtBlock' | 'id';
+  sortOrder?: 'asc' | 'desc';
+}
+
+interface GetCollectionByIdParams {
+  id: string;
+}
+
+interface GetCollectionsQuery {
+  indexerSource?: keyof typeof INDEXER_SOURCES;
+  creator?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+  sortBy?: 'createdAtBlock' | 'id';
+  sortOrder?: 'asc' | 'desc';
+}
+
+export async function collectionsRoutes(fastify: FastifyInstance) {
+  
+  // Get collections by creator
+  fastify.get<{
+    Params: GetCollectionsByCreatorParams;
+    Querystring: GetCollectionsByCreatorQuery;
+  }>('/collections/creator/:creator', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['creator'],
+        properties: {
+          creator: { type: 'string' }
+        }
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          indexerSource: { 
+            type: 'string', 
+            enum: Object.keys(INDEXER_SOURCES) 
+          },
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+          offset: { type: 'number', minimum: 0, default: 0 },
+          sortBy: { type: 'string', enum: ['createdAtBlock', 'id'], default: 'createdAtBlock' },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { creator } = request.params;
+      const { 
+        indexerSource, 
+        limit = 20, 
+        offset = 0, 
+        sortBy = 'createdAtBlock', 
+        sortOrder = 'desc' 
+      } = request.query;
+
+      const conditions = [eq(collections.creator, creator)];
+      
+      if (indexerSource) {
+        conditions.push(eq(collections.indexerSource, INDEXER_SOURCES[indexerSource]));
+      }
+
+      const orderBy = sortOrder === 'desc' 
+        ? desc(collections[sortBy]) 
+        : asc(collections[sortBy]);
+
+      const [userCollections, totalCount] = await Promise.all([
+        db
+          .select()
+          .from(collections)
+          .where(and(...conditions))
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset),
+        
+        db
+          .select({ count: count() })
+          .from(collections)
+          .where(and(...conditions))
+          .then(result => result[0].count)
+      ]);
+
+      // Enrich collections with asset counts
+      const enrichedCollections = await Promise.all(
+        userCollections.map(async (collection) => {
+          const assetCountResult = await db
+            .select({ count: count() })
+            .from(assets)
+            .where(eq(assets.collectionId, collection.id));
+          
+          return {
+            ...collection,
+            assetCount: assetCountResult[0].count
+          };
+        })
+      );
+
+      reply.send({
+        data: enrichedCollections,
+        pagination: {
+          total: totalCount,
+          limit,
+          offset,
+          hasMore: offset + limit < totalCount
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get single collection by ID
+  fastify.get<{
+    Params: GetCollectionByIdParams;
+  }>('/collections/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: { type: 'string' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { id } = request.params;
+
+      const [collection, assetCount, recentAssets] = await Promise.all([
+        db
+          .select()
+          .from(collections)
+          .where(eq(collections.id, id))
+          .limit(1),
+        
+        db
+          .select({ count: count() })
+          .from(assets)
+          .where(eq(assets.collectionId, id))
+          .then(result => result[0].count),
+
+        db
+          .select()
+          .from(assets)
+          .where(eq(assets.collectionId, id))
+          .orderBy(desc(assets.mintedAtBlock))
+          .limit(5)
+      ]);
+
+      if (collection.length === 0) {
+        reply.status(404).send({ error: 'Collection not found' });
+        return;
+      }
+
+      reply.send({ 
+        data: {
+          ...collection[0],
+          assetCount,
+          recentAssets
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get all collections with filtering
+  fastify.get<{
+    Querystring: GetCollectionsQuery;
+  }>('/collections', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          indexerSource: { 
+            type: 'string', 
+            enum: Object.keys(INDEXER_SOURCES) 
+          },
+          creator: { type: 'string' },
+          search: { type: 'string' },
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+          offset: { type: 'number', minimum: 0, default: 0 },
+          sortBy: { type: 'string', enum: ['createdAtBlock', 'id'], default: 'createdAtBlock' },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { 
+        indexerSource, 
+        creator,
+        search,
+        limit = 20, 
+        offset = 0, 
+        sortBy = 'createdAtBlock', 
+        sortOrder = 'desc' 
+      } = request.query;
+
+      const conditions = [];
+      
+      if (indexerSource) {
+        conditions.push(eq(collections.indexerSource, INDEXER_SOURCES[indexerSource]));
+      }
+      
+      if (creator) {
+        conditions.push(eq(collections.creator, creator));
+      }
+
+      if (search) {
+        conditions.push(like(collections.id, `%${search}%`));
+      }
+
+      const orderBy = sortOrder === 'desc' 
+        ? desc(collections[sortBy]) 
+        : asc(collections[sortBy]);
+
+      const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+      const [allCollections, totalCount] = await Promise.all([
+        db
+          .select()
+          .from(collections)
+          .where(whereClause)
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset),
+        
+        db
+          .select({ count: count() })
+          .from(collections)
+          .where(whereClause)
+          .then(result => result[0].count)
+      ]);
+
+      // Enrich with asset counts
+      const enrichedCollections = await Promise.all(
+        allCollections.map(async (collection) => {
+          const assetCountResult = await db
+            .select({ count: count() })
+            .from(assets)
+            .where(eq(assets.collectionId, collection.id));
+          
+          return {
+            ...collection,
+            assetCount: assetCountResult[0].count
+          };
+        })
+      );
+
+      reply.send({
+        data: enrichedCollections,
+        pagination: {
+          total: totalCount,
+          limit,
+          offset,
+          hasMore: offset + limit < totalCount
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+}

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -1,0 +1,476 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { db } from 'lib/db.api';
+import { assets, collections, transfers, INDEXER_SOURCES } from 'lib/schema';
+import { eq, desc, count, sql } from 'drizzle-orm';
+
+export async function statsRoutes(fastify: FastifyInstance) {
+  
+  // Get overall stats
+  fastify.get('/stats', async (request: FastifyRequest, reply: FastifyReply) => {
+    try {
+      const [
+        totalAssets,
+        totalCollections,
+        totalTransfers,
+        assetsByIndexer,
+        collectionsByIndexer,
+        recentActivity
+      ] = await Promise.all([
+        // Total assets count
+        db.select({ count: count() }).from(assets).then(result => result[0].count),
+        
+        // Total collections count
+        db.select({ count: count() }).from(collections).then(result => result[0].count),
+        
+        // Total transfers count
+        db.select({ count: count() }).from(transfers).then(result => result[0].count),
+        
+        // Assets by indexer source
+        db
+          .select({
+            indexerSource: assets.indexerSource,
+            count: count()
+          })
+          .from(assets)
+          .groupBy(assets.indexerSource),
+        
+        // Collections by indexer source
+        db
+          .select({
+            indexerSource: collections.indexerSource,
+            count: count()
+          })
+          .from(collections)
+          .groupBy(collections.indexerSource),
+        
+        // Recent transfer activity
+        db
+          .select({
+            id: transfers.id,
+            tokenId: transfers.tokenId,
+            from: transfers.from,
+            to: transfers.to,
+            block: transfers.block,
+            indexerSource: transfers.indexerSource
+          })
+          .from(transfers)
+          .orderBy(desc(transfers.block))
+          .limit(10)
+      ]);
+
+      reply.send({
+        data: {
+          totalAssets,
+          totalCollections,
+          totalTransfers,
+          assetsByIndexer,
+          collectionsByIndexer,
+          recentActivity
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get stats by indexer source
+  fastify.get<{
+    Querystring: { indexerSource?: keyof typeof INDEXER_SOURCES };
+  }>('/stats/indexer', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          indexerSource: { 
+            type: 'string', 
+            enum: Object.keys(INDEXER_SOURCES),
+            description: 'Filter stats by specific indexer source'
+          }
+        },
+        required: ['indexerSource']
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { indexerSource } = request.query;
+
+      if (!indexerSource) {
+        reply.status(400).send({ error: 'indexerSource query parameter is required' });
+        return;
+      }
+
+      const indexerSourceValue = INDEXER_SOURCES[indexerSource];
+
+      const [
+        totalAssets,
+        totalCollections,
+        totalTransfers,
+        topCollections,
+        topOwners,
+        recentMints
+      ] = await Promise.all([
+        // Total assets for this indexer
+        db
+          .select({ count: count() })
+          .from(assets)
+          .where(eq(assets.indexerSource, indexerSourceValue))
+          .then(result => result[0].count),
+        
+        // Total collections for this indexer
+        db
+          .select({ count: count() })
+          .from(collections)
+          .where(eq(collections.indexerSource, indexerSourceValue))
+          .then(result => result[0].count),
+        
+        // Total transfers for this indexer
+        db
+          .select({ count: count() })
+          .from(transfers)
+          .where(eq(transfers.indexerSource, indexerSourceValue))
+          .then(result => result[0].count),
+        
+        // Top collections by asset count
+        db
+          .select({
+            collectionId: assets.collectionId,
+            assetCount: count(),
+            collection: {
+              id: collections.id,
+              creator: collections.creator,
+              metadataUri: collections.metadataUri,
+              createdAtBlock: collections.createdAtBlock
+            }
+          })
+          .from(assets)
+          .leftJoin(collections, eq(assets.collectionId, collections.id))
+          .where(eq(assets.indexerSource, indexerSourceValue))
+          .groupBy(
+            assets.collectionId, 
+            collections.id, 
+            collections.creator, 
+            collections.metadataUri, 
+            collections.createdAtBlock
+          )
+          .orderBy(desc(count()))
+          .limit(5),
+        
+        // Top owners by asset count
+        db
+          .select({
+            owner: assets.owner,
+            assetCount: count()
+          })
+          .from(assets)
+          .where(eq(assets.indexerSource, indexerSourceValue))
+          .groupBy(assets.owner)
+          .orderBy(desc(count()))
+          .limit(10),
+        
+        // Recent mints (newly created assets)
+        db
+          .select({
+            id: assets.id,
+            collectionId: assets.collectionId,
+            owner: assets.owner,
+            tokenUri: assets.tokenUri,
+            mintedAtBlock: assets.mintedAtBlock
+          })
+          .from(assets)
+          .where(eq(assets.indexerSource, indexerSourceValue))
+          .orderBy(desc(assets.mintedAtBlock))
+          .limit(10)
+      ]);
+
+      reply.send({
+        data: {
+          indexerSource,
+          totalAssets,
+          totalCollections,
+          totalTransfers,
+          topCollections,
+          topOwners,
+          recentMints
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get collection stats (assets count, recent activity)
+  fastify.get<{
+    Params: { collectionId: string };
+  }>('/stats/collection/:collectionId', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['collectionId'],
+        properties: {
+          collectionId: { type: 'string' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { collectionId } = request.params;
+
+      const [
+        collection,
+        totalAssets,
+        uniqueOwners,
+        recentTransfers,
+        recentMints
+      ] = await Promise.all([
+        // Collection details
+        db
+          .select()
+          .from(collections)
+          .where(eq(collections.id, collectionId))
+          .limit(1),
+        
+        // Total assets in collection
+        db
+          .select({ count: count() })
+          .from(assets)
+          .where(eq(assets.collectionId, collectionId))
+          .then(result => result[0].count),
+        
+        // Unique owners count
+        db
+          .select({ count: sql<number>`count(distinct ${assets.owner})` })
+          .from(assets)
+          .where(eq(assets.collectionId, collectionId))
+          .then(result => result[0].count),
+        
+        // Recent transfers for this collection
+        db
+          .select({
+            id: transfers.id,
+            tokenId: transfers.tokenId,
+            from: transfers.from,
+            to: transfers.to,
+            block: transfers.block
+          })
+          .from(transfers)
+          .leftJoin(assets, eq(transfers.tokenId, assets.id))
+          .where(eq(assets.collectionId, collectionId))
+          .orderBy(desc(transfers.block))
+          .limit(10),
+        
+        // Recent mints in this collection
+        db
+          .select()
+          .from(assets)
+          .where(eq(assets.collectionId, collectionId))
+          .orderBy(desc(assets.mintedAtBlock))
+          .limit(10)
+      ]);
+
+      if (collection.length === 0) {
+        reply.status(404).send({ error: 'Collection not found' });
+        return;
+      }
+
+      reply.send({
+        data: {
+          collection: collection[0],
+          totalAssets,
+          uniqueOwners,
+          recentTransfers,
+          recentMints
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get owner stats (total assets, collections owned, recent activity)
+  fastify.get<{
+    Params: { owner: string };
+  }>('/stats/owner/:owner', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['owner'],
+        properties: {
+          owner: { type: 'string' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { owner } = request.params;
+
+      const [
+        totalAssets,
+        collectionsOwned,
+        recentAcquisitions,
+        recentSales,
+        assetsByIndexer
+      ] = await Promise.all([
+        // Total assets owned
+        db
+          .select({ count: count() })
+          .from(assets)
+          .where(eq(assets.owner, owner))
+          .then(result => result[0].count),
+        
+        // Collections this owner has assets in
+        db
+          .select({
+            collectionId: assets.collectionId,
+            assetCount: count(),
+            collection: {
+              id: collections.id,
+              creator: collections.creator,
+              metadataUri: collections.metadataUri
+            }
+          })
+          .from(assets)
+          .leftJoin(collections, eq(assets.collectionId, collections.id))
+          .where(eq(assets.owner, owner))
+          .groupBy(
+            assets.collectionId, 
+            collections.id, 
+            collections.creator, 
+            collections.metadataUri
+          )
+          .orderBy(desc(count())),
+        
+        // Recent acquisitions (transfers TO this owner)
+        db
+          .select({
+            id: transfers.id,
+            tokenId: transfers.tokenId,
+            from: transfers.from,
+            to: transfers.to,
+            block: transfers.block,
+            asset: {
+              id: assets.id,
+              collectionId: assets.collectionId,
+              tokenUri: assets.tokenUri
+            }
+          })
+          .from(transfers)
+          .leftJoin(assets, eq(transfers.tokenId, assets.id))
+          .where(eq(transfers.to, owner))
+          .orderBy(desc(transfers.block))
+          .limit(10),
+        
+        // Recent sales (transfers FROM this owner)
+        db
+          .select({
+            id: transfers.id,
+            tokenId: transfers.tokenId,
+            from: transfers.from,
+            to: transfers.to,
+            block: transfers.block,
+            asset: {
+              id: assets.id,
+              collectionId: assets.collectionId,
+              tokenUri: assets.tokenUri
+            }
+          })
+          .from(transfers)
+          .leftJoin(assets, eq(transfers.tokenId, assets.id))
+          .where(eq(transfers.from, owner))
+          .orderBy(desc(transfers.block))
+          .limit(10),
+        
+        // Assets by indexer source
+        db
+          .select({
+            indexerSource: assets.indexerSource,
+            count: count()
+          })
+          .from(assets)
+          .where(eq(assets.owner, owner))
+          .groupBy(assets.indexerSource)
+      ]);
+
+      reply.send({
+        data: {
+          owner,
+          totalAssets,
+          collectionsOwned,
+          recentAcquisitions,
+          recentSales,
+          assetsByIndexer
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get trending collections (most active in recent blocks)
+  fastify.get('/stats/trending', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          blocks: { type: 'number', minimum: 1, default: 1000, description: 'Number of recent blocks to analyze' },
+          limit: { type: 'number', minimum: 1, maximum: 50, default: 10 }
+        }
+      }
+    }
+  }, async (request: FastifyRequest<{
+    Querystring: { blocks?: number; limit?: number };
+  }>, reply) => {
+    try {
+      const { blocks = 1000, limit = 10 } = request.query;
+
+      // Get the latest block number
+      const latestBlockResult = await db
+        .select({ maxBlock: sql<number>`max(${transfers.block})` })
+        .from(transfers);
+      
+      const latestBlock = latestBlockResult[0].maxBlock || 0;
+      const fromBlock = Math.max(0, latestBlock - blocks);
+
+      // Get trending collections by transfer activity
+      const trendingCollections = await db
+        .select({
+          collectionId: assets.collectionId,
+          transferCount: count(),
+          collection: {
+            id: collections.id,
+            creator: collections.creator,
+            metadataUri: collections.metadataUri,
+            createdAtBlock: collections.createdAtBlock
+          }
+        })
+        .from(transfers)
+        .leftJoin(assets, eq(transfers.tokenId, assets.id))
+        .leftJoin(collections, eq(assets.collectionId, collections.id))
+        .where(sql`${transfers.block} >= ${fromBlock}`)
+        .groupBy(
+          assets.collectionId,
+          collections.id,
+          collections.creator,
+          collections.metadataUri,
+          collections.createdAtBlock
+        )
+        .orderBy(desc(count()))
+        .limit(limit);
+
+      reply.send({
+        data: {
+          fromBlock,
+          toBlock: latestBlock,
+          blocksAnalyzed: blocks,
+          trendingCollections
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+}

--- a/backend/src/routes/transfers.ts
+++ b/backend/src/routes/transfers.ts
@@ -1,0 +1,354 @@
+import { FastifyInstance} from 'fastify';
+import { db } from 'lib/db.api';
+import { assets, transfers, INDEXER_SOURCES } from 'lib/schema';
+import { eq, and, desc, asc, count } from 'drizzle-orm';
+
+interface GetTransfersByTokenParams {
+  tokenId: string;
+}
+
+interface GetTransfersByTokenQuery {
+  limit?: number;
+  offset?: number;
+  sortOrder?: 'asc' | 'desc';
+}
+
+interface GetTransfersQuery {
+  tokenId?: string;
+  from?: string;
+  to?: string;
+  indexerSource?: keyof typeof INDEXER_SOURCES;
+  limit?: number;
+  offset?: number;
+  sortBy?: 'block' | 'id';
+  sortOrder?: 'asc' | 'desc';
+}
+
+export async function transfersRoutes(fastify: FastifyInstance) {
+  
+  // Get transfers by token ID
+  fastify.get<{
+    Params: GetTransfersByTokenParams;
+    Querystring: GetTransfersByTokenQuery;
+  }>('/transfers/token/:tokenId', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['tokenId'],
+        properties: {
+          tokenId: { type: 'string' }
+        }
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+          offset: { type: 'number', minimum: 0, default: 0 },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { tokenId } = request.params;
+      const { limit = 20, offset = 0, sortOrder = 'desc' } = request.query;
+
+      const orderBy = sortOrder === 'desc' ? desc(transfers.block) : asc(transfers.block);
+
+      const [tokenTransfers, totalCount] = await Promise.all([
+        db
+          .select({
+            id: transfers.id,
+            tokenId: transfers.tokenId,
+            from: transfers.from,
+            to: transfers.to,
+            block: transfers.block,
+            indexerSource: transfers.indexerSource,
+            asset: {
+              id: assets.id,
+              collectionId: assets.collectionId,
+              tokenUri: assets.tokenUri,
+              owner: assets.owner
+            }
+          })
+          .from(transfers)
+          .leftJoin(assets, eq(transfers.tokenId, assets.id))
+          .where(eq(transfers.tokenId, tokenId))
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset),
+        
+        db
+          .select({ count: count() })
+          .from(transfers)
+          .where(eq(transfers.tokenId, tokenId))
+          .then(result => result[0].count)
+      ]);
+
+      reply.send({
+        data: tokenTransfers,
+        pagination: {
+          total: totalCount,
+          limit,
+          offset,
+          hasMore: offset + limit < totalCount
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get transfers by address (from)
+  fastify.get<{
+    Params: { from: string };
+    Querystring: GetTransfersByTokenQuery;
+  }>('/transfers/from/:from', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['from'],
+        properties: {
+          from: { type: 'string' }
+        }
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+          offset: { type: 'number', minimum: 0, default: 0 },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { from } = request.params;
+      const { limit = 20, offset = 0, sortOrder = 'desc' } = request.query;
+
+      const orderBy = sortOrder === 'desc' ? desc(transfers.block) : asc(transfers.block);
+
+      const [fromTransfers, totalCount] = await Promise.all([
+        db
+          .select({
+            id: transfers.id,
+            tokenId: transfers.tokenId,
+            from: transfers.from,
+            to: transfers.to,
+            block: transfers.block,
+            indexerSource: transfers.indexerSource,
+            asset: {
+              id: assets.id,
+              collectionId: assets.collectionId,
+              tokenUri: assets.tokenUri,
+              owner: assets.owner
+            }
+          })
+          .from(transfers)
+          .leftJoin(assets, eq(transfers.tokenId, assets.id))
+          .where(eq(transfers.from, from))
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset),
+        
+        db
+          .select({ count: count() })
+          .from(transfers)
+          .where(eq(transfers.from, from))
+          .then(result => result[0].count)
+      ]);
+
+      reply.send({
+        data: fromTransfers,
+        pagination: {
+          total: totalCount,
+          limit,
+          offset,
+          hasMore: offset + limit < totalCount
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get transfers by address (to)
+  fastify.get<{
+    Params: { to: string };
+    Querystring: GetTransfersByTokenQuery;
+  }>('/transfers/to/:to', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['to'],
+        properties: {
+          to: { type: 'string' }
+        }
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+          offset: { type: 'number', minimum: 0, default: 0 },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { to } = request.params;
+      const { limit = 20, offset = 0, sortOrder = 'desc' } = request.query;
+
+      const orderBy = sortOrder === 'desc' ? desc(transfers.block) : asc(transfers.block);
+
+      const [toTransfers, totalCount] = await Promise.all([
+        db
+          .select({
+            id: transfers.id,
+            tokenId: transfers.tokenId,
+            from: transfers.from,
+            to: transfers.to,
+            block: transfers.block,
+            indexerSource: transfers.indexerSource,
+            asset: {
+              id: assets.id,
+              collectionId: assets.collectionId,
+              tokenUri: assets.tokenUri,
+              owner: assets.owner
+            }
+          })
+          .from(transfers)
+          .leftJoin(assets, eq(transfers.tokenId, assets.id))
+          .where(eq(transfers.to, to))
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset),
+        
+        db
+          .select({ count: count() })
+          .from(transfers)
+          .where(eq(transfers.to, to))
+          .then(result => result[0].count)
+      ]);
+
+      reply.send({
+        data: toTransfers,
+        pagination: {
+          total: totalCount,
+          limit,
+          offset,
+          hasMore: offset + limit < totalCount
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // Get all transfers with filtering
+  fastify.get<{
+    Querystring: GetTransfersQuery;
+  }>('/transfers', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          tokenId: { type: 'string' },
+          from: { type: 'string' },
+          to: { type: 'string' },
+          indexerSource: { 
+            type: 'string', 
+            enum: Object.keys(INDEXER_SOURCES) 
+          },
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+          offset: { type: 'number', minimum: 0, default: 0 },
+          sortBy: { type: 'string', enum: ['block', 'id'], default: 'block' },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'desc' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { 
+        tokenId,
+        from,
+        to,
+        indexerSource, 
+        limit = 20, 
+        offset = 0, 
+        sortBy = 'block', 
+        sortOrder = 'desc' 
+      } = request.query;
+
+      const conditions = [];
+      
+      if (tokenId) {
+        conditions.push(eq(transfers.tokenId, tokenId));
+      }
+      
+      if (from) {
+        conditions.push(eq(transfers.from, from));
+      }
+
+      if (to) {
+        conditions.push(eq(transfers.to, to));
+      }
+
+      if (indexerSource) {
+        conditions.push(eq(transfers.indexerSource, INDEXER_SOURCES[indexerSource]));
+      }
+
+      const orderBy = sortOrder === 'desc' 
+        ? desc(transfers[sortBy]) 
+        : asc(transfers[sortBy]);
+
+      const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+      const [allTransfers, totalCount] = await Promise.all([
+        db
+          .select({
+            id: transfers.id,
+            tokenId: transfers.tokenId,
+            from: transfers.from,
+            to: transfers.to,
+            block: transfers.block,
+            indexerSource: transfers.indexerSource,
+            asset: {
+              id: assets.id,
+              collectionId: assets.collectionId,
+              tokenUri: assets.tokenUri,
+              owner: assets.owner
+            }
+          })
+          .from(transfers)
+          .leftJoin(assets, eq(transfers.tokenId, assets.id))
+          .where(whereClause)
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset),
+        
+        db
+          .select({ count: count() })
+          .from(transfers)
+          .where(whereClause)
+          .then(result => result[0].count)
+      ]);
+
+      reply.send({
+        data: allTransfers,
+        pagination: {
+          total: totalCount,
+          limit,
+          offset,
+          hasMore: offset + limit < totalCount
+        }
+      });
+    } catch (error) {
+      fastify.log.error(error);
+      reply.status(500).send({ error: 'Internal server error' });
+    }
+  });
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,12 @@
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import swagger from "@fastify/swagger";
+import swaggerUI from "@fastify/swagger-ui";
 import { assetsRoutes } from "./routes/assets";
 import { collectionsRoutes } from "./routes/collection";
 import { transfersRoutes } from "./routes/transfers";
 import { statsRoutes } from "./routes/stats";
+import { openapiSpec } from "lib/util";
 
 const fastify = Fastify({
   logger: {
@@ -33,6 +36,15 @@ fastify.register(cors, {
     }
   },
   credentials: true,
+});
+
+// --- Swagger Setup ---
+fastify.register(swagger, {
+  openapi: openapiSpec,
+});
+
+fastify.register(swaggerUI, {
+  routePrefix: "/docs",
 });
 
 // Add global error handler

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,9 @@ import { transfersRoutes } from "./routes/transfers";
 import { statsRoutes } from "./routes/stats";
 import { openapiSpec } from "lib/util";
 
+
+const port = parseInt(process.env.PORT || "3000");
+
 const fastify = Fastify({
   logger: {
     level: process.env.NODE_ENV === "production" ? "info" : "debug",
@@ -41,6 +44,7 @@ fastify.register(cors, {
 // --- Swagger Setup ---
 fastify.register(swagger, {
   openapi: openapiSpec,
+
 });
 
 fastify.register(swaggerUI, {
@@ -95,7 +99,7 @@ fastify.get("/", async (request, reply) => {
       transfers: "/api/transfers",
       stats: "/api/stats",
     },
-    documentation: "https://github.com/your-repo/nft-indexer-api",
+    documentation: process.env.NODE_ENV === "production"? "https://github.com/your-repo/nft-indexer-api" : `http://localhost:${port}/docs`,
   });
 });
 
@@ -120,7 +124,6 @@ process.on("SIGINT", gracefulShutdown);
 // Start server
 const start = async () => {
   try {
-    const port = parseInt(process.env.PORT || "3000");
     const host = process.env.HOST || "0.0.0.0";
 
     await fastify.listen({ port, host });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,148 +1,138 @@
-import Fastify from 'fastify'
+import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { assetsRoutes } from './routes/assets';
-import { collectionsRoutes } from './routes/collection';
-import { transfersRoutes } from './routes/transfers';
-import { statsRoutes } from './routes/stats';
+import { assetsRoutes } from "./routes/assets";
+import { collectionsRoutes } from "./routes/collection";
+import { transfersRoutes } from "./routes/transfers";
+import { statsRoutes } from "./routes/stats";
 
 const fastify = Fastify({
   logger: {
-    level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-  }
+    level: process.env.NODE_ENV === "production" ? "info" : "debug",
+  },
 });
 
-// Register CORS
+const defaultOrigins = [
+  "http://localhost:3000",
+  "http://localhost:3001",
+  "http://localhost:5173",
+];
+
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim())
+  : defaultOrigins;
+
 fastify.register(cors, {
-  origin: process.env.NODE_ENV === "production" ? ["https://yourdomain.com"] : true,
-  credentials: true
+  origin: (origin, cb) => {
+    // Allow requests with no origin (like curl or mobile apps)
+    if (!origin) return cb(null, true);
+
+    if (allowedOrigins.includes(origin)) {
+      cb(null, true);
+    } else {
+      cb(new Error("Not allowed by CORS"), false);
+    }
+  },
+  credentials: true,
 });
 
 // Add global error handler
 fastify.setErrorHandler(async (error, request, reply) => {
   fastify.log.error(error);
-  
+
   if (error.validation) {
     reply.status(400).send({
-      error: 'Validation Error',
-      details: error.validation
+      error: "Validation Error",
+      details: error.validation,
     });
     return;
   }
 
   reply.status(500).send({
-    error: 'Internal Server Error'
+    error: "Internal Server Error",
   });
 });
 
 // Add global preHandler for request logging
-fastify.addHook('preHandler', async (request, reply) => {
-  fastify.log.info({
-    method: request.method,
-    url: request.url,
-    params: request.params,
-    query: request.query
-  }, 'Incoming request');
+fastify.addHook("preHandler", async (request, reply) => {
+  fastify.log.info(
+    {
+      method: request.method,
+      url: request.url,
+      params: request.params,
+      query: request.query,
+    },
+    "Incoming request"
+  );
 });
 
 // Register routes
 fastify.register(assetsRoutes, { prefix: "/api" });
-
-// fastify.register(async function (fastify) {
-//   await fastify.register(collectionsRoutes);
-// }, { prefix: '/api' });
-
-// fastify.register(async function (fastify) {
-//   await fastify.register(transfersRoutes);
-// }, { prefix: '/api' });
-
-// fastify.register(async function (fastify) {
-//   await fastify.register(statsRoutes);
-// }, { prefix: '/api' });
-
-// Health check endpoint
-fastify.get('/health', async (request, reply) => {
-  try {
-    // Test database connection
-    const { db } = await import('../lib/db');
-    await db.execute('SELECT 1');
-    
-    reply.send({ 
-      status: 'ok', 
-      timestamp: new Date().toISOString(),
-      database: 'connected'
-    });
-  } catch (error:any) {
-    fastify.log.error('Health check failed:', error);
-    reply.status(503).send({ 
-      status: 'error', 
-      timestamp: new Date().toISOString(),
-      database: 'disconnected'
-    });
-  }
-});
+fastify.register(collectionsRoutes, { prefix: "/api" });
+fastify.register(transfersRoutes, { prefix: "/api" });
+fastify.register(statsRoutes, { prefix: "/api" });
 
 // Root endpoint
-fastify.get('/', async (request, reply) => {
+fastify.get("/", async (request, reply) => {
   reply.send({
-    message: 'NFT Indexer API',
-    version: '1.0.0',
+    message: "NFT Indexer API",
+    version: "1.0.0",
     endpoints: {
-      health: '/health',
-      assets: '/api/assets',
-      collections: '/api/collections',
-      transfers: '/api/transfers',
-      stats: '/api/stats'
+      health: "/health",
+      assets: "/api/assets",
+      collections: "/api/collections",
+      transfers: "/api/transfers",
+      stats: "/api/stats",
     },
-    documentation: 'https://github.com/your-repo/nft-indexer-api'
+    documentation: "https://github.com/your-repo/nft-indexer-api",
   });
 });
 
 // Graceful shutdown
 const gracefulShutdown = async () => {
-  fastify.log.info('Starting graceful shutdown...');
-  
+  fastify.log.info("Starting graceful shutdown...");
+
   try {
     await fastify.close();
-    fastify.log.info('Server closed successfully');
+    fastify.log.info("Server closed successfully");
     process.exit(0);
-  } catch (error:any) {
-    fastify.log.error('Error during shutdown:', error);
+  } catch (error: any) {
+    fastify.log.error("Error during shutdown:", error);
     process.exit(1);
   }
 };
 
 // Handle shutdown signals
-process.on('SIGTERM', gracefulShutdown);
-process.on('SIGINT', gracefulShutdown);
+process.on("SIGTERM", gracefulShutdown);
+process.on("SIGINT", gracefulShutdown);
 
 // Start server
 const start = async () => {
   try {
-    const port = parseInt(process.env.PORT || '3000');
-    const host = process.env.HOST || '0.0.0.0';
-    
+    const port = parseInt(process.env.PORT || "3000");
+    const host = process.env.HOST || "0.0.0.0";
+
     await fastify.listen({ port, host });
-    
+
     fastify.log.info(`
 🚀 NFT Indexer API Server running!
 📍 Address: http://${host}:${port}
 🏥 Health: http://${host}:${port}/health
 📚 API Base: http://${host}:${port}/api
     `);
-  } catch (err:any) {
-    fastify.log.error('Failed to start server:', err);
+  } catch (err: any) {
+    fastify.log.error("Failed to start server:", err);
     process.exit(1);
   }
 };
 
 // Handle uncaught exceptions
-process.on('uncaughtException', (error:any) => {
-  fastify.log.fatal('Uncaught Exception:', error);
+process.on("uncaughtException", (error: any) => {
+  fastify.log.fatal("Uncaught Exception:", error);
   process.exit(1);
 });
 
-process.on('unhandledRejection', (reason) => {
-  fastify.log.fatal(`Unhandled Rejection at:${reason}`,);
+process.on("unhandledRejection", (reason) => {
+  fastify.log.fatal(`Unhandled Rejection at:${reason}`);
   process.exit(1);
 });
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,149 @@
+import Fastify from 'fastify'
+import cors from "@fastify/cors";
+import { assetsRoutes } from './routes/assets';
+import { collectionsRoutes } from './routes/collection';
+import { transfersRoutes } from './routes/transfers';
+import { statsRoutes } from './routes/stats';
+
+const fastify = Fastify({
+  logger: {
+    level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+  }
+});
+
+// Register CORS
+fastify.register(cors, {
+  origin: process.env.NODE_ENV === "production" ? ["https://yourdomain.com"] : true,
+  credentials: true
+});
+
+// Add global error handler
+fastify.setErrorHandler(async (error, request, reply) => {
+  fastify.log.error(error);
+  
+  if (error.validation) {
+    reply.status(400).send({
+      error: 'Validation Error',
+      details: error.validation
+    });
+    return;
+  }
+
+  reply.status(500).send({
+    error: 'Internal Server Error'
+  });
+});
+
+// Add global preHandler for request logging
+fastify.addHook('preHandler', async (request, reply) => {
+  fastify.log.info({
+    method: request.method,
+    url: request.url,
+    params: request.params,
+    query: request.query
+  }, 'Incoming request');
+});
+
+// Register routes
+fastify.register(assetsRoutes, { prefix: "/api" });
+
+// fastify.register(async function (fastify) {
+//   await fastify.register(collectionsRoutes);
+// }, { prefix: '/api' });
+
+// fastify.register(async function (fastify) {
+//   await fastify.register(transfersRoutes);
+// }, { prefix: '/api' });
+
+// fastify.register(async function (fastify) {
+//   await fastify.register(statsRoutes);
+// }, { prefix: '/api' });
+
+// Health check endpoint
+fastify.get('/health', async (request, reply) => {
+  try {
+    // Test database connection
+    const { db } = await import('../lib/db');
+    await db.execute('SELECT 1');
+    
+    reply.send({ 
+      status: 'ok', 
+      timestamp: new Date().toISOString(),
+      database: 'connected'
+    });
+  } catch (error:any) {
+    fastify.log.error('Health check failed:', error);
+    reply.status(503).send({ 
+      status: 'error', 
+      timestamp: new Date().toISOString(),
+      database: 'disconnected'
+    });
+  }
+});
+
+// Root endpoint
+fastify.get('/', async (request, reply) => {
+  reply.send({
+    message: 'NFT Indexer API',
+    version: '1.0.0',
+    endpoints: {
+      health: '/health',
+      assets: '/api/assets',
+      collections: '/api/collections',
+      transfers: '/api/transfers',
+      stats: '/api/stats'
+    },
+    documentation: 'https://github.com/your-repo/nft-indexer-api'
+  });
+});
+
+// Graceful shutdown
+const gracefulShutdown = async () => {
+  fastify.log.info('Starting graceful shutdown...');
+  
+  try {
+    await fastify.close();
+    fastify.log.info('Server closed successfully');
+    process.exit(0);
+  } catch (error:any) {
+    fastify.log.error('Error during shutdown:', error);
+    process.exit(1);
+  }
+};
+
+// Handle shutdown signals
+process.on('SIGTERM', gracefulShutdown);
+process.on('SIGINT', gracefulShutdown);
+
+// Start server
+const start = async () => {
+  try {
+    const port = parseInt(process.env.PORT || '3000');
+    const host = process.env.HOST || '0.0.0.0';
+    
+    await fastify.listen({ port, host });
+    
+    fastify.log.info(`
+🚀 NFT Indexer API Server running!
+📍 Address: http://${host}:${port}
+🏥 Health: http://${host}:${port}/health
+📚 API Base: http://${host}:${port}/api
+    `);
+  } catch (err:any) {
+    fastify.log.error('Failed to start server:', err);
+    process.exit(1);
+  }
+};
+
+// Handle uncaught exceptions
+process.on('uncaughtException', (error:any) => {
+  fastify.log.fatal('Uncaught Exception:', error);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason) => {
+  fastify.log.fatal(`Unhandled Rejection at:${reason}`,);
+  process.exit(1);
+});
+
+start();

--- a/backend/tsconfig.api.json
+++ b/backend/tsconfig.api.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist/api",
-    "rootDir": "src",
+    "rootDir": ".",
     "declaration": true,
     "sourceMap": true
   },


### PR DESCRIPTION
**Title:** Add OpenAPI spec and Swagger UI for NFT Indexer API

**Description:**

* Added an OpenAPI 3.0.3 specification for the NFT Indexer API.
* Defined all endpoints (`/assets`, `/collections`, `/transfers`, `/stats`, `/health`) with query/path parameters and response schemas.
* Integrated Swagger UI at `/docs` for interactive API documentation so docs can be accessed via localhost:3000/docs.
* Added reusable components and paginated response schemas (`Asset`, `Collection`, `Transfer`, `Stats`, `PaginatedAssets`, `PaginatedCollections`, `PaginatedTransfers`).

**Impact:**
* Provides developers with up-to-date API documentation.
* Enables easy testing of endpoints through Swagger UI by visiting http://localhost:${port}/docs